### PR TITLE
Release of 0.9.1 is finished

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.augustcellars.cose</groupId>
     <artifactId>cose-java</artifactId>
-    <version>0.9.1-snapshot</version>
+    <version>0.9.2-snapshot</version>
 
     <name>com.augustcellars.cose:cose-java</name>
     <description>A Java implementation that supports the COSE secure message specification.</description>


### PR DESCRIPTION
We have deployed version 0.9.1 so update the internal build number