### PR TITLE
Suport for filtering KeySets using Java Lambda functions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.5.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <showDeprecation>true</showDeprecation>
                     <compilerArgument>-Xlint:unchecked</compilerArgument>
                 </configuration>

--- a/src/main/java/COSE/KeySet.java
+++ b/src/main/java/COSE/KeySet.java
@@ -3,45 +3,67 @@
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
  */
+
 package COSE;
 
-import com.upokecenter.cbor.*;
+import com.upokecenter.cbor.CBORObject;
+
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
+
 /**
  *
  * @author jimsch
  */
+/*
+ * Ways to search
+ *  - Given KeySet and key id, return a KeySet (more than one key may have the same
+ * key id)
+ *  - Filter on the algo used, key usage bits (only keys that can be used for signing, or
+ * specific types)
+ *  - Look at other fields from specs that can be used to do fast filters, vs
+ * iteration.
+ *  - By curve. Need to look at key type and curve
+ */
 public class KeySet {
-    private List<OneKey> keys;
-    
-    public KeySet() {
-        keys = new ArrayList<OneKey>();
+  private List<OneKey> keys;
+
+  public KeySet() {
+    keys = new ArrayList<OneKey>();
+  }
+
+  public KeySet(CBORObject keysIn) {
+    keys = new ArrayList<OneKey>();
+
+    // Ignore keys which we cannot deal with or are malformed.
+
+    for (int i = 0; i < keysIn.size(); i++) {
+      try {
+        keys.add(new OneKey(keysIn.get(i)));
+      } catch (CoseException e) {
+        ;
+      }
     }
-    
-    public KeySet(CBORObject keysIn) {
-        keys = new ArrayList<OneKey>();
-        
-        //  Ignore keys which we cannot deal with or are malformed.
-        
-        for (int i=0; i<keysIn.size(); i++) {
-            try {
-                keys.add(new OneKey(keysIn.get(i)));
-            } catch(CoseException e) {
-                ;
-            }
-        }
-    }
-    
-    public void add(OneKey key) {
-        keys.add(key);
-    }
-    
-    public List<OneKey> getList() {
-        return keys;
-    }
-    
-    public void remove(OneKey key) {
-        keys.remove(key);
-    }
+  }
+
+  public void add(OneKey key) {
+    keys.add(key);
+  }
+
+  public List<OneKey> getList() {
+    return keys;
+  }
+
+  public void remove(OneKey key) {
+    keys.remove(key);
+  }
+
+  public Stream<OneKey> stream() {
+    return keys.stream();
+  }
+
+  public Stream<OneKey> parallelStream() {
+    return keys.parallelStream();
+  }
 }

--- a/src/main/java/COSE/KeySetCollector.java
+++ b/src/main/java/COSE/KeySetCollector.java
@@ -1,0 +1,40 @@
+package COSE;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
+public class KeySetCollector implements Collector<OneKey, KeySet, KeySet> {
+
+  @Override
+  public Supplier<KeySet> supplier() {
+    return KeySet::new;
+  }
+
+  @Override
+  public BiConsumer<KeySet, OneKey> accumulator() {
+    return (acc, elem) -> acc.add(elem);
+  }
+
+  @Override
+  public BinaryOperator<KeySet> combiner() {
+    // parallel streams are not supported
+    return (acc1, acc2) -> {
+      throw new UnsupportedOperationException("parallel streams are not supported");
+    };
+  }
+
+  @Override
+  public Function<KeySet, KeySet> finisher() {
+    return (acc) -> acc;
+  }
+
+  @Override
+  public Set<Collector.Characteristics> characteristics() {
+    return Collections.emptySet();
+  }
+}

--- a/src/main/java/COSE/OneKey.java
+++ b/src/main/java/COSE/OneKey.java
@@ -3,12 +3,12 @@
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
  */
+
 package COSE;
 
-import com.upokecenter.cbor.*;
-import java.io.IOException;
-import java.security.PrivateKey;
-import java.security.PublicKey;
+import com.upokecenter.cbor.CBORObject;
+import com.upokecenter.cbor.CBORType;
+
 import org.bouncycastle.asn1.nist.NISTNamedCurves;
 import org.bouncycastle.asn1.x9.X9ECParameters;
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
@@ -18,238 +18,338 @@ import org.bouncycastle.crypto.params.ECKeyGenerationParameters;
 import org.bouncycastle.crypto.params.ECPrivateKeyParameters;
 import org.bouncycastle.crypto.params.ECPublicKeyParameters;
 
+import java.io.IOException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+
 /**
  *
  * @author jimsch
  */
 public class OneKey {
 
-    protected CBORObject keyMap;
-    
-    public OneKey() {
-        keyMap = CBORObject.NewMap();
+  protected CBORObject keyMap;
+
+  public OneKey() {
+    keyMap = CBORObject.NewMap();
+  }
+
+  public OneKey(CBORObject keyData) throws CoseException {
+    if (keyData.getType() != CBORType.Map)
+      throw new CoseException("Key data is malformed");
+
+    keyMap = keyData;
+    CheckKeyState();
+  }
+
+  public void add(KeyKeys keyValue, CBORObject value) {
+    keyMap.Add(keyValue.AsCBOR(), value);
+  }
+
+  public void add(CBORObject keyValue, CBORObject value) {
+    keyMap.Add(keyValue, value);
+  }
+
+  public CBORObject get(KeyKeys keyValue) {
+    return keyMap.get(keyValue.AsCBOR());
+  }
+
+  public CBORObject get(CBORObject keyValue) throws CoseException {
+    if ((keyValue.getType() != CBORType.Number) && (keyValue.getType() != CBORType.TextString))
+      throw new CoseException("keyValue type is incorrect");
+    return keyMap.get(keyValue);
+  }
+
+  /**
+   * Compares the key's assigned algorithm with the provided value, indicating if the values are the
+   * same.
+   * 
+   * @param algorithmId
+   *          the algorithm to compare or {@code null} to check for no assignment.
+   * @return {@code true} if the current key has the provided algorithm assigned, or {@code false}
+   *         otherwise
+   */
+  public boolean HasAlgorithmID(AlgorithmID algorithmId) {
+    CBORObject thisObj = get(KeyKeys.Algorithm);
+    CBORObject thatObj = (algorithmId == null ? null : algorithmId.AsCBOR());
+    boolean result;
+    if (thatObj == null) {
+      result = (thisObj == null);
+    } else {
+      result = thatObj.equals(thisObj);
     }
-    
-    public OneKey(CBORObject keyData) throws CoseException {
-        if (keyData.getType() != CBORType.Map) throw new CoseException("Key data is malformed");
-        
-        keyMap = keyData;
-        CheckKeyState();
+    return result;
+  }
+
+  /**
+   * Compares the key's assigned identifier with the provided value, indicating if the values are
+   * the same.
+   * 
+   * @param id
+   *          the identifier to compare or {@code null} to check for no assignment.
+   * @return {@code true} if the current key has the provided identifier assigned, or {@code false}
+   *         otherwise
+   */
+  public boolean HasKeyID(String id) {
+    CBORObject thatObj = (id == null) ? null : CBORObject.FromObject(id);
+    CBORObject thisObj = get(KeyKeys.KeyId);
+    boolean result;
+    if (thatObj == null) {
+      result = (thisObj == null);
+    } else {
+      result = thatObj.equals(thisObj);
     }
-    
-    public void add(KeyKeys keyValue, CBORObject value) {
-        keyMap.Add(keyValue.AsCBOR(), value);
+    return result;
+  }
+
+  /**
+   * Compares the key's assigned key type with the provided value, indicating if the values are the
+   * same.
+   * 
+   * @param keyTypeObj
+   *          the key type to compare or {@code null} to check for no assignment.
+   * @return {@code true} if the current key has the provided identifier assigned, or {@code false}
+   *         otherwise
+   */
+  public boolean HasKeyType(CBORObject keyTypeObj) {
+    CBORObject thatObj = keyTypeObj;
+    CBORObject thisObj = get(KeyKeys.KeyType);
+    boolean result;
+    if (thatObj == null) {
+      result = (thisObj == null);
+    } else {
+      result = thatObj.equals(thisObj);
     }
-    
-    public void add(CBORObject keyValue, CBORObject value) {
-        keyMap.Add(keyValue, value);
-    }
-    
-    public CBORObject get(KeyKeys keyValue) {
-        return keyMap.get(keyValue.AsCBOR());
-    }
-    
-    public CBORObject get(CBORObject keyValue) throws CoseException {
-        if ((keyValue.getType() != CBORType.Number) && (keyValue.getType() != CBORType.TextString)) throw new CoseException("keyValue type is incorrect");
-        return keyMap.get(keyValue);
-    }
-    
-    private void CheckKeyState() throws CoseException {
-        CBORObject val;
-        
-        //  Must have a key type
-        val = OneKey.this.get(KeyKeys.KeyType);
-        if ((val == null) || (val.getType() != CBORType.Number)) throw new CoseException("Missing or incorrect key type field");
-        
-        if (val.equals(KeyKeys.KeyType_Octet)) {
-            val = OneKey.this.get(KeyKeys.Octet_K);
-            if ((val== null) || (val.getType() != CBORType.ByteString)) throw new CoseException("Malformed key structure");
+    return result;
+  }
+
+  /**
+   * Compares the key's assigned key operations with the provided value, indicating if the provided
+   * value was found in the key operation values assigned to the key.
+   * 
+   * @param that
+   *          the integer operation value to attempt to find in the values provided by the key or
+   *          {@code null} to check for no assignment.
+   * @return {@code true} if the current key has the provided value assigned, or {@code false}
+   *         otherwise
+   */
+  public boolean HasKeyOp(Integer that) {
+    CBORObject thisObj = get(KeyKeys.Key_Ops);
+    boolean result;
+    if (that == null) {
+      result = (thisObj == null);
+    } else {
+      result = false;
+      if (thisObj.getType() == CBORType.Number) {
+        if (thisObj.AsInt32() == that) {
+          result = true;
         }
-        else if (val.equals(KeyKeys.KeyType_EC2)) {
-            boolean privateKey = false;
-            
-            val = OneKey.this.get(KeyKeys.EC2_D);
-            if (val != null) {
-                if (val.getType() != CBORType.ByteString) throw new CoseException("Malformed key structure");
-                privateKey = true;
-            }
-            
-            val = OneKey.this.get(KeyKeys.EC2_X);
-            if (val == null) {
-                if (!privateKey) throw new CoseException("Malformed key structure");
-            }
-            else if (val.getType() != CBORType.ByteString) throw new CoseException("Malformed key structure");
-            
-            val = OneKey.this.get(KeyKeys.EC2_Y);
-            if (val == null) {
-                if (!privateKey) throw new CoseException("Malformed key structure");
-            }
-            else if ((val.getType() != CBORType.ByteString) && (val.getType() != CBORType.Boolean)) throw new CoseException("Malformed key structure");
+      } else if (thisObj.getType() == CBORType.Array) {
+        for (int i = 0; i < thisObj.size(); i++) {
+          if ((thisObj.get(i).getType() == CBORType.Number) && (thisObj.get(i).AsInt32() == that)) {
+            result = true;
+            break;
+          }
         }
-        else throw new CoseException("Unsupported key type");
+      }
+    }
+    return result;
+  }
+
+  private void CheckKeyState() throws CoseException {
+    CBORObject val;
+
+    // Must have a key type
+    val = OneKey.this.get(KeyKeys.KeyType);
+    if ((val == null) || (val.getType() != CBORType.Number))
+      throw new CoseException("Missing or incorrect key type field");
+
+    if (val.equals(KeyKeys.KeyType_Octet)) {
+      val = OneKey.this.get(KeyKeys.Octet_K);
+      if ((val == null) || (val.getType() != CBORType.ByteString))
+        throw new CoseException("Malformed key structure");
+    } else if (val.equals(KeyKeys.KeyType_EC2)) {
+      boolean privateKey = false;
+
+      val = OneKey.this.get(KeyKeys.EC2_D);
+      if (val != null) {
+        if (val.getType() != CBORType.ByteString)
+          throw new CoseException("Malformed key structure");
+        privateKey = true;
+      }
+
+      val = OneKey.this.get(KeyKeys.EC2_X);
+      if (val == null) {
+        if (!privateKey)
+          throw new CoseException("Malformed key structure");
+      } else if (val.getType() != CBORType.ByteString)
+        throw new CoseException("Malformed key structure");
+
+      val = OneKey.this.get(KeyKeys.EC2_Y);
+      if (val == null) {
+        if (!privateKey)
+          throw new CoseException("Malformed key structure");
+      } else if ((val.getType() != CBORType.ByteString) && (val.getType() != CBORType.Boolean))
+        throw new CoseException("Malformed key structure");
+    } else
+      throw new CoseException("Unsupported key type");
+  }
+
+  public X9ECParameters GetCurve() throws CoseException {
+    if (OneKey.this.get(KeyKeys.KeyType) != KeyKeys.KeyType_EC2)
+      throw new CoseException("Not an EC2 key");
+    CBORObject cnCurve = OneKey.this.get(KeyKeys.EC2_Curve);
+
+    if (cnCurve == KeyKeys.EC2_P256)
+      return NISTNamedCurves.getByName("P-256");
+    if (cnCurve == KeyKeys.EC2_P384)
+      return NISTNamedCurves.getByName("P-384");
+    if (cnCurve == KeyKeys.EC2_P521)
+      return NISTNamedCurves.getByName("P-521");
+    throw new CoseException("Unsupported curve " + cnCurve);
+  }
+
+  static public OneKey generateKey(AlgorithmID algorithm) throws CoseException {
+    OneKey returnThis = null;
+    switch (algorithm) {
+    case ECDSA_256:
+      returnThis = generateECDSAKey("P-256", KeyKeys.EC2_P256);
+      break;
+
+    case ECDSA_384:
+      returnThis = generateECDSAKey("P-384", KeyKeys.EC2_P384);
+      break;
+
+    case ECDSA_512:
+      returnThis = generateECDSAKey("P-521", KeyKeys.EC2_P521);
+      break;
+
+    default:
+      throw new CoseException("Unknown algorithm");
     }
 
-    public X9ECParameters GetCurve() throws CoseException {    
-        if (OneKey.this.get(KeyKeys.KeyType) != KeyKeys.KeyType_EC2) throw new CoseException("Not an EC2 key");
-        CBORObject cnCurve = OneKey.this.get(KeyKeys.EC2_Curve);
-        
-        if (cnCurve == KeyKeys.EC2_P256) return NISTNamedCurves.getByName("P-256");
-        if (cnCurve == KeyKeys.EC2_P384) return NISTNamedCurves.getByName("P-384");
-        if (cnCurve == KeyKeys.EC2_P521) return NISTNamedCurves.getByName("P-521");
-        throw new CoseException("Unsupported curve " + cnCurve);
+    returnThis.add(KeyKeys.Algorithm, algorithm.AsCBOR());
+    return returnThis;
+  }
+
+  static private OneKey generateECDSAKey(String curveName, CBORObject curve) {
+    X9ECParameters p = NISTNamedCurves.getByName(curveName);
+
+    ECDomainParameters parameters = new ECDomainParameters(p.getCurve(), p.getG(), p.getN(), p.getH());
+    ECKeyPairGenerator pGen = new ECKeyPairGenerator();
+    ECKeyGenerationParameters genParam = new ECKeyGenerationParameters(parameters, null);
+    pGen.init(genParam);
+
+    AsymmetricCipherKeyPair p1 = pGen.generateKeyPair();
+
+    ECPublicKeyParameters keyPublic = (ECPublicKeyParameters) p1.getPublic();
+    ECPrivateKeyParameters keyPrivate = (ECPrivateKeyParameters) p1.getPrivate();
+
+    byte[] rgbX = keyPublic.getQ().normalize().getXCoord().getEncoded();
+    byte[] rgbY = keyPublic.getQ().normalize().getYCoord().getEncoded();
+    boolean signY = true;
+    byte[] rgbD = keyPrivate.getD().toByteArray();
+
+    OneKey key = new OneKey();
+
+    key.add(KeyKeys.KeyType, KeyKeys.KeyType_EC2);
+    key.add(KeyKeys.EC2_Curve, curve);
+    key.add(KeyKeys.EC2_X, CBORObject.FromObject(rgbX));
+    key.add(KeyKeys.EC2_Y, CBORObject.FromObject(rgbY));
+    key.add(KeyKeys.EC2_D, CBORObject.FromObject(rgbD));
+
+    return key;
+  }
+
+  /**
+   * Create a OneKey object with only the public fields. Filters out the private key fields but
+   * leaves all positive number labels and text labels along with negative number labels that are
+   * public fields.
+   * 
+   * @return public version of the key
+   */
+  public OneKey PublicKey() {
+    OneKey newKey = new OneKey();
+    CBORObject val = this.get(KeyKeys.KeyType);
+    if (val.equals(KeyKeys.KeyType_Octet)) {
+      return null;
+    } else if (val.equals(KeyKeys.KeyType_EC2)) {
+      newKey.add(KeyKeys.EC2_Curve, get(KeyKeys.EC2_Curve));
+      newKey.add(KeyKeys.EC2_X, get(KeyKeys.EC2_X));
+      newKey.add(KeyKeys.EC2_Y, get(KeyKeys.EC2_Y));
     }
-    
-    static public OneKey generateKey(AlgorithmID algorithm) throws CoseException {
-        OneKey returnThis = null;
-        switch(algorithm) {
-            case ECDSA_256:
-                returnThis = generateECDSAKey("P-256", KeyKeys.EC2_P256); 
-                break;
-                
-            case ECDSA_384:
-                returnThis = generateECDSAKey("P-384", KeyKeys.EC2_P384);
-                break;
-                
-            case ECDSA_512:
-                returnThis = generateECDSAKey("P-521", KeyKeys.EC2_P521);
-                break;
-                
-            default:
-                throw new CoseException("Unknown algorithm");
-        }
-        
-        returnThis.add(KeyKeys.Algorithm, algorithm.AsCBOR());
-        return returnThis;
-    }
-    
-    static private OneKey generateECDSAKey(String curveName, CBORObject curve) {                
-        X9ECParameters p = NISTNamedCurves.getByName(curveName);
-        
-        ECDomainParameters parameters = new ECDomainParameters(p.getCurve(), p.getG(), p.getN(), p.getH());
-        ECKeyPairGenerator pGen = new ECKeyPairGenerator();
-        ECKeyGenerationParameters genParam = new ECKeyGenerationParameters(parameters, null);
-        pGen.init(genParam);
-
-        AsymmetricCipherKeyPair p1 = pGen.generateKeyPair();
-
-        ECPublicKeyParameters keyPublic = (ECPublicKeyParameters) p1.getPublic();
-        ECPrivateKeyParameters keyPrivate = (ECPrivateKeyParameters) p1.getPrivate();
-
-        byte[] rgbX = keyPublic.getQ().normalize().getXCoord().getEncoded();
-        byte[] rgbY = keyPublic.getQ().normalize().getYCoord().getEncoded();
-        boolean signY = true;
-        byte[] rgbD = keyPrivate.getD().toByteArray();
-
-        OneKey key = new OneKey();
-
-        key.add(KeyKeys.KeyType, KeyKeys.KeyType_EC2);
-        key.add(KeyKeys.EC2_Curve, curve);
-        key.add(KeyKeys.EC2_X, CBORObject.FromObject(rgbX));
-        key.add(KeyKeys.EC2_Y, CBORObject.FromObject(rgbY));
-        key.add(KeyKeys.EC2_D, CBORObject.FromObject(rgbD));
-
-        return key;        
-    }
-    
-    /**
-     * Create a OneKey object with only the public fields.  Filters out the 
-     * private key fields but leaves all positive number labels and text labels
-     * along with negative number labels that are public fields.
-     * 
-     * @return public version of the key
+    /*
+     * else if (val.equals(KeyKeys.KeyType_OKP)) { newKey.add(KeyKeys.OKP_Curve,
+     * get(KeyKeys.OKP_Curve)); newKey.add(KeyKeys.OKP_X, get(KeyKeys.OKP_X)); }
      */
-    public OneKey PublicKey()
-    {
-        OneKey newKey = new OneKey();
-        CBORObject val = this.get(KeyKeys.KeyType);
-        if (val.equals(KeyKeys.KeyType_Octet)) {
-            return null;
-        }
-        else if (val.equals(KeyKeys.KeyType_EC2)) {
-            newKey.add(KeyKeys.EC2_Curve, get(KeyKeys.EC2_Curve));
-            newKey.add(KeyKeys.EC2_X, get(KeyKeys.EC2_X));
-            newKey.add(KeyKeys.EC2_Y, get(KeyKeys.EC2_Y));
-        }
-        /*
-        else if (val.equals(KeyKeys.KeyType_OKP)) {
-            newKey.add(KeyKeys.OKP_Curve, get(KeyKeys.OKP_Curve));
-            newKey.add(KeyKeys.OKP_X, get(KeyKeys.OKP_X));
-        }
-        */
-        else {
-            return null;
-        }
+    else {
+      return null;
+    }
 
-        for (CBORObject obj : keyMap.getKeys()) {
-            val = keyMap.get(obj);
-            if (obj.getType() == CBORType.Number) {
-                if (obj.AsInt32() > 0) {
-                    newKey.add(obj, val);
-                }
-            }
-            else if (obj.getType() == CBORType.TextString) {
-                newKey.add(obj, val);
-            }
+    for (CBORObject obj : keyMap.getKeys()) {
+      val = keyMap.get(obj);
+      if (obj.getType() == CBORType.Number) {
+        if (obj.AsInt32() > 0) {
+          newKey.add(obj, val);
         }
-        return newKey;
+      } else if (obj.getType() == CBORType.TextString) {
+        newKey.add(obj, val);
+      }
     }
-    
-    /**
-     * Encode to a byte string
-     * 
-     * @return encoded object as bytes.
-     */
-    public byte[] EncodeToBytes()
-    {
-        return keyMap.EncodeToBytes();
+    return newKey;
+  }
+
+  /**
+   * Encode to a byte string
+   * 
+   * @return encoded object as bytes.
+   */
+  public byte[] EncodeToBytes() {
+    return keyMap.EncodeToBytes();
+  }
+
+  /**
+   * Return the key as a CBOR object
+   * 
+   * @return
+   */
+  public CBORObject AsCBOR() {
+    return keyMap;
+  }
+
+  /**
+   * Return a java.security.PublicKey that is the same as the OneKey key
+   * 
+   * @return the key
+   * @throws CoseException
+   *           If there is a conversion error
+   */
+  public PublicKey AsPublicKey() throws CoseException {
+    if (get(KeyKeys.KeyType).equals(KeyKeys.KeyType_EC2)) {
+      try {
+        return new ECPublicKey(this);
+      } catch (IOException e) {
+        throw new CoseException("Internal Error encoding the key");
+      }
     }
-    
-    /**
-     * Return the key as a CBOR object
-     * 
-     * @return 
-     */
-    public CBORObject AsCBOR()
-    {
-        return keyMap;
+    throw new CoseException("Cannot convert key as key type is not converted");
+  }
+
+  /**
+   * Return a java.security.PrivateKey that is the same as the OneKey key
+   * 
+   * @return the key
+   * @throws CoseException
+   *           if there is a conversion error
+   */
+  public PrivateKey AsPrivateKey() throws CoseException {
+    if (get(KeyKeys.KeyType).equals(KeyKeys.KeyType_EC2)) {
+      try {
+        return new ECPrivateKey(this);
+      } catch (IOException ex) {
+        throw new CoseException("Internal error encoding the key");
+      }
     }
-    
-    /**
-     * Return a java.security.PublicKey that is the same as the OneKey key
-     * 
-     * @return the key
-     * @throws CoseException If there is a conversion error
-     */
-    public PublicKey AsPublicKey() throws CoseException
-    {
-        if (get(KeyKeys.KeyType).equals(KeyKeys.KeyType_EC2))
-        {
-            try {
-                return new ECPublicKey(this);
-            }
-            catch (IOException e) {
-                throw new CoseException("Internal Error encoding the key");
-            }
-        }
-        throw new CoseException("Cannot convert key as key type is not converted");
-    }
-    
-    /**
-     * Return a java.security.PrivateKey that is the same as the OneKey key
-     * 
-     * @return the key
-     * @throws CoseException if there is a conversion error
-     */
-    public PrivateKey AsPrivateKey() throws CoseException
-    {
-        if (get(KeyKeys.KeyType).equals(KeyKeys.KeyType_EC2))
-        {
-            try {
-                return new ECPrivateKey(this);
-            } catch (IOException ex) {
-                throw new CoseException("Internal error encoding the key");
-            }
-        }
-        throw new CoseException("Cannot convert key as key type is not converted");
-    }
+    throw new CoseException("Cannot convert key as key type is not converted");
+  }
 }

--- a/src/test/java/COSE/KeySetTest.java
+++ b/src/test/java/COSE/KeySetTest.java
@@ -1,5 +1,5 @@
-package COSE;
 
+package COSE;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -8,10 +8,11 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class KeySetTest {
-  
+
   /**
    * Test of stream method of class KeySet.
-   * @throws CoseException 
+   * 
+   * @throws CoseException
    */
   @Test
   public void testStream() throws CoseException {
@@ -20,18 +21,25 @@ public class KeySetTest {
     ks.add(ecdsa_256);
     ks.add(OneKey.generateKey(AlgorithmID.ECDSA_512));
 
-    List<OneKey> filteredKeys = ks.stream()
-        .filter(k-> k.HasAlgorithmID(AlgorithmID.ECDSA_256))
-        .collect(Collectors.toList());
+    KeySet newKeys = ks.stream()
+        .filter(k -> k.HasAlgorithmID(AlgorithmID.ECDSA_256))
+        .collect(new KeySetCollector());
+    List<OneKey> filteredKeys = newKeys.getList();
     Assert.assertEquals(1, filteredKeys.size());
     Assert.assertEquals(ecdsa_256, filteredKeys.get(0));
 
-    // Do something like the following
-    filteredKeys = ks.stream()
+    newKeys = ks.stream()
         .filter(k -> AlgorithmID.ECDSA_256.AsCBOR().equals(k.get(KeyKeys.Algorithm)))
-        .collect(Collectors.toList());
+        .collect(new KeySetCollector());
+    filteredKeys = newKeys.getList();
     Assert.assertEquals(1, filteredKeys.size());
     Assert.assertEquals(ecdsa_256, filteredKeys.get(0));
+
+    newKeys = ks.stream()
+        .filter(k -> k.HasAlgorithmID(AlgorithmID.ECDSA_384))
+        .collect(new KeySetCollector());
+    filteredKeys = newKeys.getList();
+    Assert.assertEquals(0, filteredKeys.size());
   }
 
 }

--- a/src/test/java/COSE/KeySetTest.java
+++ b/src/test/java/COSE/KeySetTest.java
@@ -1,0 +1,37 @@
+package COSE;
+
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class KeySetTest {
+  
+  /**
+   * Test of stream method of class KeySet.
+   * @throws CoseException 
+   */
+  @Test
+  public void testStream() throws CoseException {
+    KeySet ks = new KeySet();
+    OneKey ecdsa_256 = OneKey.generateKey(AlgorithmID.ECDSA_256);
+    ks.add(ecdsa_256);
+    ks.add(OneKey.generateKey(AlgorithmID.ECDSA_512));
+
+    List<OneKey> filteredKeys = ks.stream()
+        .filter(k-> k.HasAlgorithmID(AlgorithmID.ECDSA_256))
+        .collect(Collectors.toList());
+    Assert.assertEquals(1, filteredKeys.size());
+    Assert.assertEquals(ecdsa_256, filteredKeys.get(0));
+
+    // Do something like the following
+    filteredKeys = ks.stream()
+        .filter(k -> AlgorithmID.ECDSA_256.AsCBOR().equals(k.get(KeyKeys.Algorithm)))
+        .collect(Collectors.toList());
+    Assert.assertEquals(1, filteredKeys.size());
+    Assert.assertEquals(ecdsa_256, filteredKeys.get(0));
+  }
+
+}

--- a/src/test/java/COSE/OneKeyTest.java
+++ b/src/test/java/COSE/OneKeyTest.java
@@ -3,6 +3,7 @@
  * To change this template file, choose Tools | Templates
  * and open the template in the editor.
  */
+
 package COSE;
 
 import com.upokecenter.cbor.CBORObject;
@@ -13,12 +14,16 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.bouncycastle.asn1.x9.X9ECParameters;
 import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
 import org.bouncycastle.crypto.generators.ECKeyPairGenerator;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -30,209 +35,262 @@ import org.junit.Ignore;
  * @author jimsch
  */
 public class OneKeyTest {
-    
-    public OneKeyTest() {
-    }
-    
-    @BeforeClass
-    public static void setUpClass() {
-    }
-    
-    @AfterClass
-    public static void tearDownClass() {
-    }
-    
-    @Before
-    public void setUp() {
-    }
-    
-    @After
-    public void tearDown() {
-    }
 
-    /**
-     * Test of add method, of class OneKey.
-     */
-    @Ignore
-    @Test
-    public void testAdd_KeyKeys_CBORObject() {
-        System.out.println("add");
-        KeyKeys keyValue = null;
-        CBORObject value = null;
-        OneKey instance = new OneKey();
-        instance.add(keyValue, value);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
+  public OneKeyTest() {
+  }
 
-    /**
-     * Test of add method, of class OneKey.
-     */
-    @Ignore
-    @Test
-    public void testAdd_CBORObject_CBORObject() {
-        System.out.println("add");
-        CBORObject keyValue = null;
-        CBORObject value = null;
-        OneKey instance = new OneKey();
-        instance.add(keyValue, value);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
+  @BeforeClass
+  public static void setUpClass() {
+  }
 
-    /**
-     * Test of get method, of class OneKey.
-     */
-    @Ignore
-    @Test
-    public void testGet_KeyKeys() {
-        System.out.println("get");
-        KeyKeys keyValue = null;
-        OneKey instance = new OneKey();
-        CBORObject expResult = null;
-        CBORObject result = instance.get(keyValue);
-        assertEquals(expResult, result);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
+  @AfterClass
+  public static void tearDownClass() {
+  }
 
-    /**
-     * Test of get method, of class OneKey.
-     */
-    @Ignore
-    @Test
-    public void testGet_CBORObject() throws Exception {
-        System.out.println("get");
-        CBORObject keyValue = null;
-        OneKey instance = new OneKey();
-        CBORObject expResult = null;
-        CBORObject result = instance.get(keyValue);
-        assertEquals(expResult, result);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
+  @Before
+  public void setUp() {
+  }
 
-    /**
-     * Test of GetCurve method, of class OneKey.
-     */
-    @Ignore
-    @Test
-    public void testGetCurve() throws Exception {
-        System.out.println("GetCurve");
-        OneKey instance = new OneKey();
-        X9ECParameters expResult = null;
-        X9ECParameters result = instance.GetCurve();
-        assertEquals(expResult, result);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
+  @After
+  public void tearDown() {
+  }
 
-    /**
-     * Test of generateKey method, of class OneKey.
-     */
-    @Ignore
-    @Test
-    public void testGenerateKey() throws Exception {
-        System.out.println("generateKey");
-        AlgorithmID algorithm = null;
-        OneKey expResult = null;
-        OneKey result = OneKey.generateKey(algorithm);
-        assertEquals(expResult, result);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
+  /**
+   * Test of add method, of class OneKey.
+   */
+  @Ignore
+  @Test
+  public void testAdd_KeyKeys_CBORObject() {
+    System.out.println("add");
+    KeyKeys keyValue = null;
+    CBORObject value = null;
+    OneKey instance = new OneKey();
+    instance.add(keyValue, value);
+    // TODO review the generated test code and remove the default call to fail.
+    fail("The test case is a prototype.");
+  }
 
-    /**
-     * Test of PublicKey method, of class OneKey.
-     */
-    @Ignore
-    @Test
-    public void testPublicKey() {
-        System.out.println("PublicKey");
-        OneKey instance = new OneKey();
-        OneKey expResult = null;
-        OneKey result = instance.PublicKey();
-        assertEquals(expResult, result);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
+  /**
+   * Test of add method, of class OneKey.
+   */
+  @Ignore
+  @Test
+  public void testAdd_CBORObject_CBORObject() {
+    System.out.println("add");
+    CBORObject keyValue = null;
+    CBORObject value = null;
+    OneKey instance = new OneKey();
+    instance.add(keyValue, value);
+    // TODO review the generated test code and remove the default call to fail.
+    fail("The test case is a prototype.");
+  }
 
-    /**
-     * Test of EncodeToBytes method, of class OneKey.
-     */
-    @Ignore
-    @Test
-    public void testEncodeToBytes() {
-        System.out.println("EncodeToBytes");
-        OneKey instance = new OneKey();
-        byte[] expResult = null;
-        byte[] result = instance.EncodeToBytes();
-        assertArrayEquals(expResult, result);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
+  /**
+   * Test of get method, of class OneKey.
+   */
+  @Ignore
+  @Test
+  public void testGet_KeyKeys() {
+    System.out.println("get");
+    KeyKeys keyValue = null;
+    OneKey instance = new OneKey();
+    CBORObject expResult = null;
+    CBORObject result = instance.get(keyValue);
+    assertEquals(expResult, result);
+    // TODO review the generated test code and remove the default call to fail.
+    fail("The test case is a prototype.");
+  }
 
-    /**
-     * Test of AsCBOR method, of class OneKey.
-     */
-    @Ignore
-    @Test
-    public void testAsCBOR() {
-        System.out.println("AsCBOR");
-        OneKey instance = new OneKey();
-        CBORObject expResult = null;
-        CBORObject result = instance.AsCBOR();
-        assertEquals(expResult, result);
-        // TODO review the generated test code and remove the default call to fail.
-        fail("The test case is a prototype.");
-    }
+  /**
+   * Test of get method, of class OneKey.
+   */
+  @Ignore
+  @Test
+  public void testGet_CBORObject() throws Exception {
+    System.out.println("get");
+    CBORObject keyValue = null;
+    OneKey instance = new OneKey();
+    CBORObject expResult = null;
+    CBORObject result = instance.get(keyValue);
+    assertEquals(expResult, result);
+    // TODO review the generated test code and remove the default call to fail.
+    fail("The test case is a prototype.");
+  }
 
-    /**
-     * Test of AsPublicKey method, of class OneKey.
-     */
-    @Test
-    public void testAsPublicKey() throws Exception {
-        OneKey instance = OneKey.generateKey(AlgorithmID.ECDSA_256);
-        PublicKey result = instance.AsPublicKey();
-        assertEquals(result.getAlgorithm(), "EC");
-        assertEquals(result.getFormat(), "X.509");
-        
-        byte[] rgbSPKI = result.getEncoded();
-        String f =  byteArrayToHex(rgbSPKI);
-        assertEquals(rgbSPKI.length, 91);
-        
-        KeyFactory kFactory = KeyFactory.getInstance("EC", new BouncyCastleProvider());
-        X509EncodedKeySpec spec = new X509EncodedKeySpec(rgbSPKI);
-        PublicKey pubKey = (PublicKey) kFactory.generatePublic(spec);
-    }
+  /**
+   * Test of GetCurve method, of class OneKey.
+   */
+  @Ignore
+  @Test
+  public void testGetCurve() throws Exception {
+    System.out.println("GetCurve");
+    OneKey instance = new OneKey();
+    X9ECParameters expResult = null;
+    X9ECParameters result = instance.GetCurve();
+    assertEquals(expResult, result);
+    // TODO review the generated test code and remove the default call to fail.
+    fail("The test case is a prototype.");
+  }
 
-    /**
-     * Test of AsPrivateKey method, of class OneKey.
-     */
-    @Test
-    public void testAsPrivateKey() throws Exception {
-        OneKey instance = OneKey.generateKey(AlgorithmID.ECDSA_256);
-        PrivateKey result = instance.AsPrivateKey();
-        
-        assertEquals(result.getAlgorithm(), "EC");
-        assertEquals(result.getFormat(), "PKCS#8");
-        
-        byte[] rgbPrivate = result.getEncoded();
-        String x = byteArrayToHex(rgbPrivate);
-        
-        KeyPairGenerator kpgen = KeyPairGenerator.getInstance("EC");
+  /**
+   * Test of generateKey method, of class OneKey.
+   */
+  @Ignore
+  @Test
+  public void testGenerateKey() throws Exception {
+    System.out.println("generateKey");
+    AlgorithmID algorithm = null;
+    OneKey expResult = null;
+    OneKey result = OneKey.generateKey(algorithm);
+    assertEquals(expResult, result);
+    // TODO review the generated test code and remove the default call to fail.
+    fail("The test case is a prototype.");
+  }
 
-        KeyFactory kFactory = KeyFactory.getInstance("EC", new BouncyCastleProvider());
-                
-        PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(rgbPrivate);
-        PrivateKey pubKey = (PrivateKey) kFactory.generatePrivate(spec);
-    }
-    
-    static String byteArrayToHex(byte[] a) {
-       StringBuilder sb = new StringBuilder(a.length * 2);
-   for(byte b: a)
+  /**
+   * Test of PublicKey method, of class OneKey.
+   */
+  @Ignore
+  @Test
+  public void testPublicKey() {
+    System.out.println("PublicKey");
+    OneKey instance = new OneKey();
+    OneKey expResult = null;
+    OneKey result = instance.PublicKey();
+    assertEquals(expResult, result);
+    // TODO review the generated test code and remove the default call to fail.
+    fail("The test case is a prototype.");
+  }
+
+  /**
+   * Test of EncodeToBytes method, of class OneKey.
+   */
+  @Ignore
+  @Test
+  public void testEncodeToBytes() {
+    System.out.println("EncodeToBytes");
+    OneKey instance = new OneKey();
+    byte[] expResult = null;
+    byte[] result = instance.EncodeToBytes();
+    assertArrayEquals(expResult, result);
+    // TODO review the generated test code and remove the default call to fail.
+    fail("The test case is a prototype.");
+  }
+
+  /**
+   * Test of AsCBOR method, of class OneKey.
+   */
+  @Ignore
+  @Test
+  public void testAsCBOR() {
+    System.out.println("AsCBOR");
+    OneKey instance = new OneKey();
+    CBORObject expResult = null;
+    CBORObject result = instance.AsCBOR();
+    assertEquals(expResult, result);
+    // TODO review the generated test code and remove the default call to fail.
+    fail("The test case is a prototype.");
+  }
+
+  /**
+   * Test of AsPublicKey method, of class OneKey.
+   */
+  @Test
+  public void testAsPublicKey() throws Exception {
+    OneKey instance = OneKey.generateKey(AlgorithmID.ECDSA_256);
+    PublicKey result = instance.AsPublicKey();
+    assertEquals(result.getAlgorithm(), "EC");
+    assertEquals(result.getFormat(), "X.509");
+
+    byte[] rgbSPKI = result.getEncoded();
+    String f = byteArrayToHex(rgbSPKI);
+    assertEquals(rgbSPKI.length, 91);
+
+    KeyFactory kFactory = KeyFactory.getInstance("EC", new BouncyCastleProvider());
+    X509EncodedKeySpec spec = new X509EncodedKeySpec(rgbSPKI);
+    PublicKey pubKey = (PublicKey) kFactory.generatePublic(spec);
+  }
+
+  /**
+   * Test of AsPrivateKey method, of class OneKey.
+   */
+  @Test
+  public void testAsPrivateKey() throws Exception {
+    OneKey instance = OneKey.generateKey(AlgorithmID.ECDSA_256);
+    PrivateKey result = instance.AsPrivateKey();
+
+    assertEquals(result.getAlgorithm(), "EC");
+    assertEquals(result.getFormat(), "PKCS#8");
+
+    byte[] rgbPrivate = result.getEncoded();
+    String x = byteArrayToHex(rgbPrivate);
+
+    KeyPairGenerator kpgen = KeyPairGenerator.getInstance("EC");
+
+    KeyFactory kFactory = KeyFactory.getInstance("EC", new BouncyCastleProvider());
+
+    PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(rgbPrivate);
+    PrivateKey pubKey = (PrivateKey) kFactory.generatePrivate(spec);
+  }
+
+  static String byteArrayToHex(byte[] a) {
+    StringBuilder sb = new StringBuilder(a.length * 2);
+    for (byte b : a)
       sb.append(String.format("%02x", b & 0xff));
-   return sb.toString();
-    }
-    
+    return sb.toString();
+  }
+
+  @Test
+  public void testHasAlgorithmID_null() {
+    OneKey key = new OneKey();
+    Assert.assertTrue(key.HasAlgorithmID(null));
+    Assert.assertFalse(key.HasAlgorithmID(AlgorithmID.ECDSA_384));
+  }
+
+  @Test
+  public void testHasAlgorithmID_value() throws CoseException {
+    OneKey key = OneKey.generateKey(AlgorithmID.ECDSA_256);
+    Assert.assertTrue(key.HasAlgorithmID(AlgorithmID.ECDSA_256));
+    Assert.assertFalse(key.HasAlgorithmID(AlgorithmID.ECDSA_384));
+  }
+
+  @Test
+  public void testHasKeyID_null() {
+    OneKey key = new OneKey();
+    Assert.assertTrue(key.HasKeyID(null));
+  }
+
+  @Test
+  public void testHasKeyID_value() {
+    String idStr = "testId";
+    OneKey key = new OneKey();
+    CBORObject id = CBORObject.FromObject(idStr);
+    key.add(KeyKeys.KeyId, id);
+    Assert.assertTrue(key.HasKeyID(idStr));
+  }
+
+  @Test
+  public void testHasKeyOp_null() {
+    OneKey key = new OneKey();
+    Assert.assertTrue(key.HasKeyOp(null));
+  }
+
+  @Test
+  public void testHasKeyOp_value() {
+    OneKey key = new OneKey();
+    key.add(KeyKeys.Key_Ops, CBORObject.FromObject(2));
+    Assert.assertTrue(key.HasKeyOp(2));
+  }
+
+  @Test
+  public void testHasKeyType_null() {
+    OneKey key = new OneKey();
+    Assert.assertTrue(key.HasKeyType(null));
+  }
+
+  @Test
+  public void testHasKeyType_value() throws CoseException {
+    OneKey key = OneKey.generateKey(AlgorithmID.ECDSA_256);
+    Assert.assertTrue(key.HasKeyType(KeyKeys.KeyType_EC2));
+  }
 }


### PR DESCRIPTION
Added support for filtering KeySet instances based on OneKey properties. Convenience methods were added to OneKey to support comparison operations.