### PR TITLE
Add test for a key identifier as binary

### DIFF
--- a/src/main/java/COSE/OneKey.java
+++ b/src/main/java/COSE/OneKey.java
@@ -8,6 +8,7 @@ package COSE;
 import com.upokecenter.cbor.CBORObject;
 import com.upokecenter.cbor.CBORType;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 
 import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyFactory;
@@ -174,7 +175,14 @@ public class OneKey {
      * @return {@code true} if the current key has the provided identifier assigned, or {@code false}
      *         otherwise
      */
+    @Deprecated
     public boolean HasKeyID(String id) {
+        byte[] idB = StandardCharsets.UTF_8.encode(id).array();
+        return HasKeyID(idB);
+    }
+    
+    public boolean HasKeyID(byte[] id)
+    {
         CBORObject thatObj = (id == null) ? null : CBORObject.FromObject(id);
         CBORObject thisObj = get(KeyKeys.KeyId);
         boolean result;
@@ -183,7 +191,7 @@ public class OneKey {
         } else {
             result = thatObj.equals(thisObj);
         }    
-        return result;
+        return result;        
     }
 
     /**

--- a/src/test/java/COSE/OneKeyTest.java
+++ b/src/test/java/COSE/OneKeyTest.java
@@ -7,6 +7,7 @@ package COSE;
 
 import com.upokecenter.cbor.CBORObject;
 import com.upokecenter.cbor.CBORType;
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyFactory;
 import java.security.KeyPair;
@@ -100,6 +101,7 @@ public class OneKeyTest extends TestBase {
 
     /**
      * Test of get method, of class OneKey.
+     * @throws java.lang.Exception
      */
     @Ignore
     @Test
@@ -116,6 +118,7 @@ public class OneKeyTest extends TestBase {
 
     /**
      * Test of generateKey method, of class OneKey.
+     * @throws java.lang.Exception
      */
     @Ignore
     @Test
@@ -176,6 +179,7 @@ public class OneKeyTest extends TestBase {
 
     /**
      * Test of AsPublicKey method, of class OneKey.
+     * @throws java.lang.Exception
      */
     @Test
     public void testAsPublicKey() throws Exception {
@@ -195,6 +199,7 @@ public class OneKeyTest extends TestBase {
 
     /**
      * Test of AsPrivateKey method, of class OneKey.
+     * @throws java.lang.Exception
      */
     @Test
     public void testAsPrivateKey() throws Exception {
@@ -237,16 +242,18 @@ public class OneKeyTest extends TestBase {
     @Test
     public void testHasKeyID_null() {
         OneKey key = new OneKey();
-        Assert.assertTrue(key.HasKeyID(null));
+        Assert.assertTrue(key.HasKeyID((byte[]) null));
     }
 
     @Test
     public void testHasKeyID_value() {
         String idStr = "testId";
+        byte[] bStr = StandardCharsets.UTF_8.encode(idStr).array();
         OneKey key = new OneKey();
-        CBORObject id = CBORObject.FromObject(idStr);
+        CBORObject id = CBORObject.FromObject(bStr);
         key.add(KeyKeys.KeyId, id);
         Assert.assertTrue(key.HasKeyID(idStr));
+        Assert.assertTrue(key.HasKeyID(bStr));
     }
 
     @Test

--- a/src/test/java/COSE/RegressionTest.java
+++ b/src/test/java/COSE/RegressionTest.java
@@ -958,6 +958,14 @@ public class RegressionTest extends TestBase {
                 case "k_hex":
                     cnKeyOut.set(CBORObject.FromObject(-1), CBORObject.FromObject(hexStringToByteArray(cnValue.AsString())));
                     break;
+                    
+                case "kid":
+                    cnKeyOut.set(CBORObject.FromObject(KeyKeys.KeyId), CBORObject.FromObject(StandardCharsets.UTF_8.encode(cnValue.AsString()).array()));
+                    break;
+                    
+                case "kid_hex":
+                    cnKeyOut.set(CBORObject.FromObject(KeyKeys.KeyId), CBORObject.FromObject(hexStringToByteArray(cnValue.AsString())));
+                    break;
             }
         }
         


### PR DESCRIPTION
Should have caught this and didn't before.  Add binary check and deprecate the string version