### PR TITLE
Update dependencies + force using EdDSA provider for EdDSA keys

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,24 +97,24 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.54</version>
+            <version>1.62</version>
 	    <scope>test</scope>
 	</dependency>
         <dependency>
           <groupId>org.bouncycastle</groupId>
           <artifactId>bcpkix-jdk15on</artifactId>
-          <version>1.54</version>
+          <version>1.62</version>
 	  <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.upokecenter</groupId>
             <artifactId>cbor</artifactId>
-            <version>3.4.0</version>
+            <version>3.5.0</version>
         </dependency>
         <dependency>
             <groupId>com.github.peteroupc</groupId>
             <artifactId>numbers</artifactId>
-            <version>1.2.1</version>
+            <version>1.4.0</version>
         </dependency>
 
         <dependency>
@@ -139,7 +139,7 @@
         <dependency>
             <groupId>net.i2p.crypto</groupId>
             <artifactId>eddsa</artifactId>
-            <version>0.2.0</version>
+            <version>0.3.0</version>
             <type>jar</type>
         </dependency>
     </dependencies>

--- a/src/main/java/COSE/OneKey.java
+++ b/src/main/java/COSE/OneKey.java
@@ -767,7 +767,7 @@ public class OneKey {
                     byte[] privateKeyBytes = ASN1.EncodeOctetString(val.GetByteString());
                     byte[] pkcs8 = ASN1.EncodePKCS8(ASN1.AlgorithmIdentifier(oid, null), privateKeyBytes, null);
                     
-                    KeyFactory fact = KeyFactory.getInstance(algName);
+                    KeyFactory fact = KeyFactory.getInstance(algName, "EdDSA");
                     KeySpec keyspec = new PKCS8EncodedKeySpec(pkcs8);
 
                     privateKey = fact.generatePrivate(keyspec);
@@ -803,12 +803,12 @@ public class OneKey {
                 spki = ASN1.EncodeSubjectPublicKeyInfo(ASN1.AlgorithmIdentifier(oid, null), rgbKey);        
             }
        
-            KeyFactory fact = KeyFactory.getInstance("EdDSA");
+            KeyFactory fact = KeyFactory.getInstance("EdDSA", "EdDSA");
             KeySpec keyspec = new X509EncodedKeySpec(spki);
             publicKey = fact.generatePublic(keyspec);
         }
-        catch (NoSuchAlgorithmException e) {
-            throw new CoseException("Alorithm unsupported", e);
+        catch (NoSuchAlgorithmException | NoSuchProviderException e) {
+            throw new CoseException("Algorithm unsupported", e);
         }
         catch (InvalidKeySpecException e) {
             throw new CoseException("Internal error on SPKI", e);
@@ -832,7 +832,7 @@ public class OneKey {
             }
 
             EdDSAGenParameterSpec paramSpec = new EdDSAGenParameterSpec(curveName);
-            KeyPairGenerator gen = KeyPairGenerator.getInstance("EdDSA");
+            KeyPairGenerator gen = KeyPairGenerator.getInstance("EdDSA", "EdDSA");
             gen.initialize(paramSpec);
             
             KeyPair keyPair = gen.genKeyPair();
@@ -851,7 +851,7 @@ public class OneKey {
             
             return key;
         }
-        catch (NoSuchAlgorithmException e) {
+        catch (NoSuchAlgorithmException | NoSuchProviderException e) {
             throw new CoseException("No provider for algorithm", e);
         }
         catch (InvalidAlgorithmParameterException e) {

--- a/src/main/java/COSE/SignCommon.java
+++ b/src/main/java/COSE/SignCommon.java
@@ -26,6 +26,7 @@ public abstract class SignCommon extends Message {
 
     static byte[] computeSignature(AlgorithmID alg, byte[] rgbToBeSigned, OneKey cnKey) throws CoseException {
         String      algName = null;
+        String      provider = null;
         int         sigLen = 0;
         
         switch (alg) {
@@ -43,6 +44,7 @@ public abstract class SignCommon extends Message {
                 break;
             case EDDSA:
                 algName = "NonewithEdDSA";
+                provider = "EdDSA";
                 break;
                 
             default:
@@ -60,7 +62,8 @@ public abstract class SignCommon extends Message {
         
         byte[]      result = null;
         try {
-            Signature sig = Signature.getInstance(algName);
+            Signature sig = provider == null ? Signature.getInstance(algName) :
+                    Signature.getInstance(algName, provider);
             sig.initSign(privKey);
             sig.update(rgbToBeSigned);
             result = sig.sign();
@@ -126,6 +129,7 @@ public abstract class SignCommon extends Message {
 
     static boolean validateSignature(AlgorithmID alg, byte[] rgbToBeSigned, byte[] rgbSignature, OneKey cnKey) throws CoseException {
         String algName = null;
+        String provider = null;
         boolean convert = false;
 
         switch (alg) {
@@ -144,6 +148,7 @@ public abstract class SignCommon extends Message {
             
         case EDDSA:
             algName = "NonewithEdDSA";
+            provider = "EdDSA";
             break;
 
         default:
@@ -161,7 +166,8 @@ public abstract class SignCommon extends Message {
 
         boolean result = false;
         try {
-            Signature sig = Signature.getInstance(algName);
+            Signature sig = provider == null ? Signature.getInstance(algName) :
+                    Signature.getInstance(algName, provider);
             sig.initVerify(pubKey);
             sig.update(rgbToBeSigned);
 


### PR DESCRIPTION
Update dependencies and force using EdDSA provider for EdDSA keys

After 1.59 Bouncy Castle seems to have added EdDSA keys support, and it seems that using the security provider index is not working.

To answer @jimsch's question in jimsch/COSE-JAVA#1, I wanted to use the latest BouncyCastle versions (with all CVE fixes) but that breaks the tests because they added support EdDSA keys. Leveraging the security provider order to implicitly use the `net.i2p.crypto.eddsa` provider does not appear to work. The code already depends on using `net.i2p.crypto.eddsa` for EdDSA, so I think that explicitly selecting the provider is acceptable.