### PR TITLE
Delete unused dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,31 +111,7 @@
             <artifactId>cbor</artifactId>
             <version>3.5.0</version>
         </dependency>
-        <dependency>
-            <groupId>com.github.peteroupc</groupId>
-            <artifactId>numbers</artifactId>
-            <version>1.4.0</version>
-        </dependency>
 
-        <dependency>
-            <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-java</artifactId>
-            <scope>test</scope>
-            <version>2.44.0</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.opera</groupId>
-            <artifactId>operadriver</artifactId>
-            <scope>test</scope>
-            <version>1.5</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.seleniumhq.selenium</groupId>
-                    <artifactId>selenium-remote-driver</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
         <dependency>
             <groupId>net.i2p.crypto</groupId>
             <artifactId>eddsa</artifactId>


### PR DESCRIPTION
This started as Yubico/java-webauthn-server#36.

The direct dependency on `com.github.peteroupc:numbers` causes dependency convergence issues for users using the Maven Enforcer plugin, because the direct dependency version does not agree with the transitive dependency version from `com.upokecenter:cbor`:

```[INFO] --- maven-enforcer-plugin:1.4.1:enforce (enforce) @ cose-java ---
[WARNING]
Dependency convergence error for com.github.peteroupc:numbers:1.3.1 paths to dependency are:
+-com.augustcellars.cose:cose-java:0.9.10
  +-com.upokecenter:cbor:3.5.0
    +-com.github.peteroupc:numbers:1.3.1
and
+-com.augustcellars.cose:cose-java:0.9.10
  +-com.github.peteroupc:numbers:1.4.0
```

The classes from the `numbers` package are never referenced directly in the COSE-JAVA sources, so this dependency turns out not to be needed.

While investigating this I also discovered that the test dependencies on `selenium-java` and `operadriver` are also unused, so those can be deleted as well.