### PR TITLE
Support for parsing EdDSA-related key types from Java objects to OneKey

### DIFF
--- a/src/main/java/COSE/ASN1.java
+++ b/src/main/java/COSE/ASN1.java
@@ -252,6 +252,33 @@ public class ASN1 {
     }
     
     /**
+     * Decode an array of bytes which is supposed to be an ASN.1 encoded octet string.
+     * 
+     * @param offset - starting offset in array to begin decoding
+     * @param encoding - bytes of the ASN.1 encoded value
+     * @return Decoded structure
+     * @throws CoseException - ASN.1 encoding errors
+     */
+    public static TagValue DecodeSimple(int offset, byte[] encoding) throws CoseException {
+        ArrayList<TagValue> result = new ArrayList<TagValue>();
+        int retTag = encoding[offset];
+
+        if (encoding[offset] != 0x04)
+            throw new CoseException("Invalid structure");
+        int[] l = DecodeLength(offset + 1, encoding);
+
+        int sequenceLength = l[1];
+        if (offset + 2 + sequenceLength != encoding.length)
+            throw new CoseException("Invalid sequence");
+
+        int tag = encoding[offset];
+        offset += 1 + l[0];
+        result.add(new TagValue(tag, Arrays.copyOfRange(encoding, offset, offset + l[1])));
+
+        return new TagValue(retTag, result);
+    }
+
+    /**
      * Encode a private key into a PKCS#8 private key structure.
      * 
      * @param algorithm - EC curve OID
@@ -371,8 +398,16 @@ public class ASN1 {
         //  Decode the contents of the octet string PrivateKey
 
         byte[] pk = pkcs8.get(2).value;
+        TagValue pkd;
 
-        TagValue pkd = DecodeCompound(0, pk);
+        // First check if it can be decoded as a simple value
+        if (pk[0] == 0x04) { // ASN.1 Octet string
+            pkd = DecodeSimple(0, pk);
+            return pkd.list;
+        }
+
+        // Otherwise proceed to parse as compound value
+        pkd = DecodeCompound(0, pk);
         ArrayList<TagValue> pkdl = pkd.list;
         if (pkd.tag != 0x30) throw new CoseException("Invalid ECPrivateKey");
         if (pkdl.size() < 2 || pkdl.size() > 4) throw new CoseException("Invalid ECPrivateKey");

--- a/src/main/java/COSE/ASN1.java
+++ b/src/main/java/COSE/ASN1.java
@@ -97,15 +97,12 @@ public class ASN1 {
     private static final int IntegerTag = 2;
 
     /**
-     * Determine if a specific OID is matching one used for ECDH or EdDSA.
-     * See https://www.iana.org/assignments/cose/cose.xhtml#elliptic-curves
-     * 
-     * This means it is matching either Ed25519, Ed448, X25519 or X448.
+     * Determine if a specific OID is matching either Ed25519, Ed448, X25519 or X448.
      * 
      * @param oid the OID to check
      * @return if it is matching Ed25519, Ed448, X25519 or X448
      */
-    public static boolean isEcdhEddsaOid(byte[] oid) {
+    public static boolean isEdXOid(byte[] oid) {
         return Arrays.equals(oid, ASN1.Oid_Ed25519) || Arrays.equals(oid, ASN1.Oid_Ed448)
                 || Arrays.equals(oid, ASN1.Oid_X25519) || Arrays.equals(oid, ASN1.Oid_X448);
     }

--- a/src/main/java/COSE/ASN1.java
+++ b/src/main/java/COSE/ASN1.java
@@ -106,12 +106,8 @@ public class ASN1 {
      * @return if it is matching Ed25519, Ed448, X25519 or X448
      */
     public static boolean isEcdhEddsaOid(byte[] oid) {
-        if (Arrays.equals(oid, ASN1.Oid_Ed25519) || Arrays.equals(oid, ASN1.Oid_Ed448)
-                || Arrays.equals(oid, ASN1.Oid_X25519) || Arrays.equals(oid, ASN1.Oid_X448)) {
-            return true;
-        } else {
-            return false;
-        }
+        return Arrays.equals(oid, ASN1.Oid_Ed25519) || Arrays.equals(oid, ASN1.Oid_Ed448)
+                || Arrays.equals(oid, ASN1.Oid_X25519) || Arrays.equals(oid, ASN1.Oid_X448);
     }
 
     /**

--- a/src/main/java/COSE/ASN1.java
+++ b/src/main/java/COSE/ASN1.java
@@ -97,6 +97,24 @@ public class ASN1 {
     private static final int IntegerTag = 2;
 
     /**
+     * Determine if a specific OID is matching one used for ECDH or EdDSA.
+     * See https://www.iana.org/assignments/cose/cose.xhtml#elliptic-curves
+     * 
+     * This means it is matching either Ed25519, Ed448, X25519 or X448.
+     * 
+     * @param oid the OID to check
+     * @return if it is matching Ed25519, Ed448, X25519 or X448
+     */
+    public static boolean isEcdhEddsaOid(byte[] oid) {
+        if (Arrays.equals(oid, ASN1.Oid_Ed25519) || Arrays.equals(oid, ASN1.Oid_Ed448)
+                || Arrays.equals(oid, ASN1.Oid_X25519) || Arrays.equals(oid, ASN1.Oid_X448)) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
      * Encode a subject public key info structure from an OID and the data bytes
      * for the key
      * This function assumes that we are encoding an EC Public key.d

--- a/src/main/java/COSE/OneKey.java
+++ b/src/main/java/COSE/OneKey.java
@@ -108,10 +108,7 @@ public class OneKey {
 
                 keyMap.Add(KeyKeys.RSA_N.AsCBOR(), n.value);
                 keyMap.Add(KeyKeys.RSA_E.AsCBOR(), e.value);
-            } else if (Arrays.equals(alg.get(0).value, ASN1.Oid_Ed25519)
-                    || Arrays.equals(alg.get(0).value, ASN1.Oid_Ed448)
-                    || Arrays.equals(alg.get(0).value, ASN1.Oid_X25519)
-                    || Arrays.equals(alg.get(0).value, ASN1.Oid_X448)) {
+            } else if (ASN1.isEcdhEddsaOid(alg.get(0).value)) {
                 byte[] oid = (byte[]) alg.get(0).value;
                 if (oid == null)
                     throw new CoseException("Invalid SPKI structure");
@@ -189,10 +186,7 @@ public class OneKey {
                 keyMap.Add(KeyKeys.RSA_QI.AsCBOR(), pkdl.get(8).value);
 
                 // todo multi prime keys
-            } else if (Arrays.equals(alg.get(0).value, ASN1.Oid_Ed25519)
-                    || Arrays.equals(alg.get(0).value, ASN1.Oid_Ed448)
-                    || Arrays.equals(alg.get(0).value, ASN1.Oid_X25519)
-                    || Arrays.equals(alg.get(0).value, ASN1.Oid_X448)) {
+            } else if (ASN1.isEcdhEddsaOid(alg.get(0).value)) {
                 byte[] oid = (byte[]) alg.get(0).value;
                 if (oid == null)
                     throw new CoseException("Invalid PKCS8 structure");

--- a/src/main/java/COSE/OneKey.java
+++ b/src/main/java/COSE/OneKey.java
@@ -108,7 +108,7 @@ public class OneKey {
 
                 keyMap.Add(KeyKeys.RSA_N.AsCBOR(), n.value);
                 keyMap.Add(KeyKeys.RSA_E.AsCBOR(), e.value);
-            } else if (ASN1.isEcdhEddsaOid(alg.get(0).value)) {
+            } else if (ASN1.isEdXOid(alg.get(0).value)) {
                 byte[] oid = (byte[]) alg.get(0).value;
                 if (oid == null)
                     throw new CoseException("Invalid SPKI structure");
@@ -186,7 +186,7 @@ public class OneKey {
                 keyMap.Add(KeyKeys.RSA_QI.AsCBOR(), pkdl.get(8).value);
 
                 // todo multi prime keys
-            } else if (ASN1.isEcdhEddsaOid(alg.get(0).value)) {
+            } else if (ASN1.isEdXOid(alg.get(0).value)) {
                 byte[] oid = (byte[]) alg.get(0).value;
                 if (oid == null)
                     throw new CoseException("Invalid PKCS8 structure");

--- a/src/main/java/COSE/OneKey.java
+++ b/src/main/java/COSE/OneKey.java
@@ -108,6 +108,33 @@ public class OneKey {
 
                 keyMap.Add(KeyKeys.RSA_N.AsCBOR(), n.value);
                 keyMap.Add(KeyKeys.RSA_E.AsCBOR(), e.value);
+            } else if (Arrays.equals(alg.get(0).value, ASN1.Oid_Ed25519)
+                    || Arrays.equals(alg.get(0).value, ASN1.Oid_Ed448)
+                    || Arrays.equals(alg.get(0).value, ASN1.Oid_X25519)
+                    || Arrays.equals(alg.get(0).value, ASN1.Oid_X448)) {
+                byte[] oid = (byte[]) alg.get(0).value;
+                if (oid == null)
+                    throw new CoseException("Invalid SPKI structure");
+                
+                // OKP Key
+                keyMap.Add(KeyKeys.KeyType.AsCBOR(), KeyKeys.KeyType_OKP);
+                keyMap.Add(KeyKeys.Algorithm.AsCBOR(), AlgorithmID.EDDSA.AsCBOR());
+                if (Arrays.equals(oid, ASN1.Oid_X25519))
+                    keyMap.Add(KeyKeys.OKP_Curve.AsCBOR(), KeyKeys.OKP_X25519);
+                else if (Arrays.equals(oid, ASN1.Oid_X448))
+                    keyMap.Add(KeyKeys.OKP_Curve.AsCBOR(), KeyKeys.OKP_X448);
+                else if (Arrays.equals(oid, ASN1.Oid_Ed25519))
+                    keyMap.Add(KeyKeys.OKP_Curve.AsCBOR(), KeyKeys.OKP_Ed25519);
+                else if (Arrays.equals(oid, ASN1.Oid_Ed448))
+                    keyMap.Add(KeyKeys.OKP_Curve.AsCBOR(), KeyKeys.OKP_Ed448);
+                else
+                    throw new CoseException("Unsupported curve");
+
+                byte[] keyData = (byte[]) spki.get(1).value;
+                if (keyData[0] == 0) {
+                    keyMap.Add(KeyKeys.OKP_X.AsCBOR(), Arrays.copyOfRange(keyData, 1, keyData.length));
+                } else
+                    throw new CoseException("Invalid key data");
             }
             else {
                 throw new CoseException("Unsupported Algorithm");
@@ -162,6 +189,39 @@ public class OneKey {
                 keyMap.Add(KeyKeys.RSA_QI.AsCBOR(), pkdl.get(8).value);
 
                 // todo multi prime keys
+            } else if (Arrays.equals(alg.get(0).value, ASN1.Oid_Ed25519)
+                    || Arrays.equals(alg.get(0).value, ASN1.Oid_Ed448)
+                    || Arrays.equals(alg.get(0).value, ASN1.Oid_X25519)
+                    || Arrays.equals(alg.get(0).value, ASN1.Oid_X448)) {
+                byte[] oid = (byte[]) alg.get(0).value;
+                if (oid == null)
+                    throw new CoseException("Invalid PKCS8 structure");
+                // OKP Key
+                if (!keyMap.ContainsKey(KeyKeys.KeyType.AsCBOR())) {
+
+                    keyMap.Add(KeyKeys.Algorithm.AsCBOR(), AlgorithmID.EDDSA.AsCBOR());
+                    if (Arrays.equals(oid, ASN1.Oid_X25519))
+                        keyMap.Add(KeyKeys.OKP_Curve.AsCBOR(), KeyKeys.OKP_X25519);
+                    else if (Arrays.equals(oid, ASN1.Oid_X448))
+                        keyMap.Add(KeyKeys.OKP_Curve.AsCBOR(), KeyKeys.OKP_X448);
+                    else if (Arrays.equals(oid, ASN1.Oid_Ed25519))
+                        keyMap.Add(KeyKeys.OKP_Curve.AsCBOR(), KeyKeys.OKP_Ed25519);
+                    else if (Arrays.equals(oid, ASN1.Oid_Ed448))
+                        keyMap.Add(KeyKeys.OKP_Curve.AsCBOR(), KeyKeys.OKP_Ed448);
+                    else
+                        throw new CoseException("Unsupported curve");
+
+                } else {
+                    if (!this.get(KeyKeys.KeyType).equals(KeyKeys.KeyType_OKP)) {
+                        throw new CoseException("Public/Private key don't match");
+                    }
+                }
+
+                ArrayList<ASN1.TagValue> pkdl = ASN1.DecodePKCS8EC(pkl);
+                if (pkdl.get(0).tag != 4)
+                    throw new CoseException("Invalid PKCS8 structure");
+                byte[] keyData = (byte[]) (pkdl.get(0).value);
+                keyMap.Add(KeyKeys.OKP_D.AsCBOR(), keyData);
             }
             else {
                 throw new CoseException("Unsupported Algorithm");


### PR DESCRIPTION
This pull request enables parsing keys from Java objects into OneKey objects for keys using curves such as Ed25519.

Currently, code such as the following using ECDSA 256 works:
```
OneKey ecdsaOneKey = OneKey.generateKey(AlgorithmID.ECDSA_256);
PrivateKey javaPrivate = ecdsaOneKey.AsPrivateKey();
PublicKey javaPublic = ecdsaOneKey.AsPublicKey();
OneKey rebuiltOneKey = new OneKey(javaPublic, javaPrivate);
```

However the following code with EdDSA does not:
```
Provider EdDSA = new EdDSASecurityProvider(); // net.i2p.crypto.eddsa provider
Security.insertProviderAt(EdDSA, 0);
OneKey eddsaOneKey = OneKey.generateKey(AlgorithmID.EDDSA);
PrivateKey javaPrivate = eddsaOneKey.AsPrivateKey();
PublicKey javaPublic = eddsaOneKey.AsPublicKey();
OneKey rebuiltOneKey = new OneKey(javaPublic, javaPrivate);
```

It will instead cause an "Unsupported Algorithm" exception at
https://github.com/cose-wg/COSE-JAVA/blob/0385f31bfcfb2793abb9d6a6560acf7f9a405269/src/main/java/COSE/OneKey.java#L113

This is because the parsing in OneKey does not handle these key types. This pull request aims to fix this and also allow for parsing of keys using for instance Ed25519.